### PR TITLE
Improve installation and configuration process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,7 @@ TESTS = tests/*.js tests/managers/*.js
 REPORTER = dot
 
 install:
-	mkdir -p data/tmp \
-	mkdir -p data/channels \
-	mkdir -p data/cdn/img/av \
-	mkdir -p data/cdn/img/icofactory \
-	mkdir -p data/cdn/img/pods \	
-	@SYSTEM_TZ=`/usr/bin/env date +%Z` ./tools/setup.js \
+	@SYSTEM_TZ=`/usr/bin/env date +%Z` ./tools/setup.js
 
 test-install:
 	@NODE_ENV=testing ./tools/setup.js

--- a/README.md
+++ b/README.md
@@ -140,16 +140,17 @@ SMTP Bips are available out of the box with a Haraka plugin.  Configs under [bip
 
 #### via npm
 
-    npm install bipio
-    cd node_modules/bipio
-    node ./src/server.js
+    npm install -g bipio
+    export NODE_CONFIG_DIR=<path_to_your_config_directory>
+    bipio-setup
+    bipio
 
 #### via git
 
     git clone git@github.com:bipio-server/bipio.git
     cd bipio
     make install
-    node ./src/server.js
+    node .
 
 Be sure to have a MongoDB server and Rabbit broker ready and available before install.  Otherwise, follow the prompts
 during the install process to get a basically sane server running that you can play with.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,19 @@
   "author": "Michael Pearson",
   "name": "bipio",
   "version": "0.2.41",
+  "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "install": "make install"
+    "test": "make test"
+  },
+  "bin": {
+    "bipio": "./src/server.js",
+    "bipio-setup": "./tools/setup.js",
+    "bipio-token-regen": "./tools/token_regen.js",
+    "bipio-pod-install": "./tools/pod-install.js",
+    "bipio-trigger": "./tools/bip-trigger.js",
+    "bipio-expire": "./tools/bip-expire.js",
+    "bipio-generate-hub-stats": "./tools/generate-hub-stats.js"
   },
   "description": "API and graph resolver for the bipio content pipeline.",
   "homepage": "https://bip.io",
@@ -53,6 +63,7 @@
     "mkdirp": ">=0.3.5",
     "mongoose": ">=3.8.0",
     "multer": "0.0.6",
+    "node-fs": "^0.1.7",
     "node-uuid": "1.3.3",
     "passport": ">=0.1.15",
     "posix-getopt": "1.1.0",

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -21,8 +21,8 @@
  * A Bipio Commercial OEM License may be obtained via enquiries@cloudspark.com.au
  */
 
-// always look to local config
-process.env.NODE_CONFIG_DIR = __dirname + '/../config';
+process.env.NODE_CONFIG_DIR =
+  process.env.NODE_CONFIG_DIR || __dirname + '/../config';
 process.env.MONGOOSE_DISABLE_STABILITY_WARNING = true;
 // includes
 var app = {
@@ -48,8 +48,8 @@ GLOBAL.CFG_CDN = envConfig.cdn;
 GLOBAL.CFG = envConfig;
 GLOBAL.DEFS = defs;
 GLOBAL.SERVER_ROOT = path.resolve(__dirname);
-GLOBAL.DATA_DIR = GLOBAL.SERVER_ROOT + '/../' + envConfig.datadir,
-GLOBAL.CDN_DIR = GLOBAL.SERVER_ROOT + '/../' + envConfig.cdn;
+GLOBAL.DATA_DIR = envConfig.dataDir;
+GLOBAL.CDN_DIR = envConfig.cdn;
 
 // attach general helpers to the app
 app.helper = helper;

--- a/tools/pod-install.js
+++ b/tools/pod-install.js
@@ -58,22 +58,27 @@ if (program.add) {
     mode = 'remove';
     podName = program.remove;
 }
+
+function modulePath(name) {
+    var podPath = require.resolve(name);
+    var node_modules = podPath.split(name).slice(0, -1).join(name); 
+    return path.join(node_modules, name);
+}
+
 try {
-    pod = require('bip-pod-' + podName);
+    pod = require("bip-pod-" + podName);
+    podPath = modulePath("bip-pod-" + podName); 
 } catch (Err) {
     console.log(Err.toString());
     console.log('Trying literal module name...');
-    pod = require(podName)
+    pod = require(podName);
+    podPath = modulePath(podName);
 }
 
-var appEnv = process.env.NODE_ENV;
-if (appEnv === 'development' || !appEnv) {
-    appEnv = 'default';
-}
-
-if (pod && pod._name) {
-    var configFile = path.resolve(__dirname + '/../config/' + appEnv + '.json'),
-      corpusFile = path.resolve(__dirname + '/node_modules/bip-pod-' + podName + '/corpus.json');
+if (pod && podPath) {
+    var 
+      configFile = GLOBAL.CFG.getConfigSources()[0].name,
+      corpusFile = path.join(podPath, 'corpus.json');
 
     console.log('Installing "' + podName + '" POD');
 
@@ -82,7 +87,7 @@ if (pod && pod._name) {
     config = pod._config || {};
 
     if (currentConfig) {
-        var imgDir = __dirname + '/../data/cdn/img/pods';
+        var imgDir = GLOBAL.CDN_DIR + '/img/pods';
         if (!fs.existsSync(imgDir)) {
             helper.mkdir_p(imgDir);
 
@@ -113,9 +118,9 @@ if (pod && pod._name) {
             console.log('Wrote to ' + configFile);
         } else {
             console.log('Skipped write. Nothing to change');
-            var podIcon = __dirname + '/../node_modules/bip-pod-' + podName + '/' + podName + '.png';
+            var podIcon = path.join(podPath, podName + '.png');
             if (fs.existsSync(podIcon)) {
-                fs.createReadStream(podIcon).pipe(fs.createWriteStream(imgDir + '/' + podName + '.png'));
+                fs.createReadStream(podIcon).pipe(fs.createWriteStream(path.join(imgDir, podName + '.png')));
                 console.log('Icon Synced');
             }
         }


### PR DESCRIPTION
**Do not merge yet, still a few(mostly docs) changes to come.**
## Motivation:

In a process of packaging bipio for our distribution(nixos) i found it hard to
decouple code, configuration and data. These paths were hardcoded, but could be
easily made variable, giving system adiministrator control where to put
configuration and data. Also there was no way to install package non
interactivelly, because running npm install spawns interactive setup script.
## Changes:
- setup script: add optional environment variable to run it non-interactivelly
- setup script: add options to select data and cdn directory(full paths)
- package.json: do not run setup script on install, it's installation not
  setup, packaing is not a phase where database is configured
- package.json: add several script for starting bipio and for tools(including
  for setup)
- bootstrap.js: use NODE_CONFIG_DIR env variable if set, otherwise use
  hardcoded config path
- bootstrap.js: use datadir and cdn from config file(they are now full paths)
- pod-install.js: make more portable, pods might be in other locations
  specified by NODE_PATH, also use configuration path from GLOBAL.CFG, defined by
  bootstrap
- README: update readme with new installation and configuration process,
  changes especially if installing with npm
## Warning:

This process breaks configuration back compatibility, because datadir and cdn are now full paths!
